### PR TITLE
Add xcolor package.

### DIFF
--- a/dtx/ncsuthesis.dtx
+++ b/dtx/ncsuthesis.dtx
@@ -303,6 +303,7 @@ and the derived files           ncsuthesis.ins,
 \RequirePackage{ifthen}
 \RequirePackage{sectsty}
 \RequirePackage{tocloft}
+\RequirePackage[svgnames]{xcolor}
 \RequirePackage{graphicx}
 \RequirePackage[nottoc]{tocbibind} % includes lof, lot, refs in toc
 \RequirePackage{calc}


### PR DESCRIPTION
The `xcolor` has to appear in the `dtx` file because `graphicx` appears in the `dtx` file. Otherwise, introducing this package will result in an option clash.