### PR TITLE
Move punctuation in "Under the direction of..."

### DIFF
--- a/dtx/ncsuthesis.dtx
+++ b/dtx/ncsuthesis.dtx
@@ -513,7 +513,7 @@ and the derived files           ncsuthesis.ins,
     \nohyphens{\nolbreaks{\ncsu@thesistitle}.
    (Under the direction of
    \ifthenelse{\equal{\ncsu@chairtype}{chair}}%
-              {\ncsu@chair}{\ncsu@cochairI\ and \ncsu@cochairII}.)}\\
+              {\ncsu@chair}{\ncsu@cochairI\ and \ncsu@cochairII}).}\\
 
    \ncsu@defaultspacing
     % make (hidden) page numbers for the pre-frontmatter alphabetic


### PR DESCRIPTION
Move the period outside the parenthesis on the first page (Under the direction of...). This change is for consistency with the MS Word template.